### PR TITLE
feat: on focus auto selects all content

### DIFF
--- a/src/views/FareShare/FareShare.tsx
+++ b/src/views/FareShare/FareShare.tsx
@@ -59,6 +59,7 @@ const FareShare: React.FC<FareShareProps> = () => {
                 textFieldProps={{
                   label: 'Total',
                   size: 'small',
+                  onFocus: (e) => e.target.setSelectionRange(0, e.target.value.length)
                 }}
               />
             </Grid2>

--- a/src/views/FareShare/LineItem.tsx
+++ b/src/views/FareShare/LineItem.tsx
@@ -22,6 +22,7 @@ const LineItemSection: React.FC<LineItemProps> = (props) => {
           fullWidth
           value={lineItem.itemName}
           onChange={(e) => onChange({ ...lineItem, itemName: e.target.value })}
+          onFocus={(e) => e.target.setSelectionRange(0, e.target.value.length)}
           slotProps={{
             input: {
               startAdornment: (
@@ -35,7 +36,7 @@ const LineItemSection: React.FC<LineItemProps> = (props) => {
       </Grid2>
       <Grid2 size={4}>
         <FloatField
-          textFieldProps={{ fullWidth: true }}
+          textFieldProps={{ fullWidth: true, onFocus: (e) => e.target.setSelectionRange(0, e.target.value.length) }}
           value={lineItem.cost}
           onChange={(cost) => onChange({ ...lineItem, cost })}
         />

--- a/src/views/FareShare/PersonSection.tsx
+++ b/src/views/FareShare/PersonSection.tsx
@@ -49,6 +49,7 @@ const PersonSection: React.FC<PersonSectionProps> = (props) => {
             },
           }}
           onChange={(e) => onChange({ ...value, name: e.target.value })}
+          onFocus={(e) => e.target.setSelectionRange(0, e.target.value.length)}
         />
       </Grid2>
       <Grid2 size={4} display="flex" alignItems="center" gap={1}>


### PR DESCRIPTION
It was annoying to try to clear the content of the input every time you wanted to change the value. Now, clicking on the input will immediately select the full text for convenient replacement.